### PR TITLE
Fix build error

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-LIBS = `pkg-config --libs gtk+-2.0 gthread-2.0` -lpng
+LIBS = `pkg-config --libs gtk+-2.0 gthread-2.0` -lpng -lm
 CFLAGS = -Wall -pedantic
 GFLAGS = $(CFLAGS) `pkg-config --cflags gtk+-2.0 gthread-2.0`
 PREFIX = /usr/local


### PR DESCRIPTION
Fix this build error:

gcc -g -o wavejet main.o cbk.o gui.o scp.o numbers.o png.o data.c prf.o `pkg-config --libs gtk+-2.0 gthread-2.0` -lpng
/usr/bin/ld: gui.o: undefined reference to symbol 'round@@GLIBC_2.2.5'
/usr/bin/ld: /lib/x86_64-linux-gnu/libm.so.6: error adding symbols: No DSO specified on command line